### PR TITLE
How to update a PDF coverpage

### DIFF
--- a/part3.adoc
+++ b/part3.adoc
@@ -698,6 +698,37 @@ State transition diagrams and lifecycle illustrations help users understand:
 
 These diagrams are typically hand-crafted using PlantUML and integrated into the generated documentation.
 
+[[userguide-cover-page]]
+==== Cover Page
+
+The cover page holds the document control information. The fields used are shown in the table below.
+
+[cols="1,3"]
+|===
+| Field | Description
+
+| `:RELEASE-STATUS:`
+| The document status, either "Preview" or "Production"
+
+| `:MATURITY-LEVEL:`
+| "General availability (GA)"
+
+| `:TEAM-DATE:`
+| When the team/architect approved the document, in the format `dd-Mmm-yyyy`
+
+| `:APPROVAL-STATUS:`
+| "Team Approved"
+
+| `:IPR-MODE:`
+| "RAND"
+
+| `:VERSION:`
+| The full version of this API, e.g. "5.1.2"
+
+|===
+
+Update or add the values in the `userguide.adoc` file.
+
 === Conformance Profile Deep Dive
 
 The Conformance Profile defines exactly what an API implementation must support to be considered compliant with the TMForum specification.
@@ -731,6 +762,10 @@ When standard patterns don't fit your API requirements:
 5. **Update documentation**: Ensure the User Guide reflects the custom requirements
 
 Custom rules should align with TMForum API Design Guidelines while addressing specific domain needs.
+
+==== Cover Page
+
+The conformance profile document includes a cover page with document control information. The fields and format are the same as for the User Guide; see <<userguide-cover-page>> in the User Guide Deep Dive section for details.
 
 === Configuration File Deep Dive
 


### PR DESCRIPTION
We have a few different fields in the `userguide.adoc` and `conformance.adoc` files that need to be updated to make the cover pages work, but it isn't always clear which ones or what the correct values would be. I've now added a section on this so we can refer to it (under user guide with a note and link to that section from the conformance profile part).

@knutaa can you double check this looks right? We didn't have any docs that I could find but this is what I've been doing to get the coversheets with the right values :) There are other date/revision fields, but I assume they are not needed.