### PR TITLE
How to update the conformance YAML file

### DIFF
--- a/part3.adoc
+++ b/part3.adoc
@@ -711,6 +711,14 @@ The profile is automatically generated from your rules file, particularly:
 * Parameter restrictions (specified in `parameterRestrictions`)
 * Required notification events
 
+You can regenerate the conformance profile without losing existing content by creating the file `documentation/conformance/config.yaml` with the line:
+
+```yaml
+updateConformanceYaml: true
+```
+
+It is not recommended to commit this change to source control.
+
 ==== How to Read the Profile
 
 The conformance profile uses a structured format:


### PR DESCRIPTION
There's a configuration setting that can be applied if you want the conformance.yaml to be updated when you generate the PDF file. This pull request adds that information to the developer guide.